### PR TITLE
[add]お酒を最新の日付順に並べ替えする機能

### DIFF
--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -14,7 +14,6 @@ const Catalog = () => {
   //お酒リストを取ってくる処理
   useEffect(() => {
     if (user != null) {
-      console.log(user.uid);
       firebase
         .firestore()
         .collection(user.uid)
@@ -22,11 +21,24 @@ const Catalog = () => {
           const drinks = querySnapshot.docs.map((doc) => {
             return { ...doc.data(), id: doc.id };
           });
+          //お酒一覧をソートする処理
+          //①各お酒のdatesの配列を降順（最新順）にする
+          drinks.forEach((drink, i) => {
+            drink.dates.sort((a, b) => b - a);
+          });
+          //②各お酒の最新の日付を比較してお酒一覧を降順にする
+          drinks.sort((a, b) => {
+            if (a.dates[0] > b.dates[0]) {
+              return -1;
+            } else {
+              return 1;
+            }
+          });
+          //ソートしたものをセット
           setDrinks(drinks);
         });
     }
   }, [user]);
-  console.log(drinks);
 
   return (
     <>


### PR DESCRIPTION
## Issue

Closes #40

## 今回の PR で行ったこと

- 仮データをfirestoreに手動で保存、お酒のdatesを配列にして複数登録
- drinksの各drinkデータのdatesを降順に並び替え(インデックス0が最新の日付になる）
- 各drinkのdates[0]を比較し、drinksを降順に並び替え

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- レンダリング結果を確認。降順にソートされていた。

## 懸念点

- 今後、Edit.jsでのfirestoreでの保存手順に、dateをtimestampでお酒のdocに配列で追加していく手順を加える必要があります。
