### PR TITLE
<catalog.js>ユーザーごとの動的なルーティングにアップデート

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,19 +4,19 @@ import Item from "./Components/Item";
 import Catalog from "./Components/Catalog";
 import { SignUp } from "./Components/SignUp";
 import Login from "./Components/Login";
-//import firebase from "./config/firebase";
-import { AuthProvider } from "./Components/AuthService"
+// import firebase from "./config/firebase";
+import { AuthProvider } from "./Components/AuthService";
 import LoggedInRoute from "./Components/LoggedInRoute";
-
+import Home from "./Components/Home";
 
 const App = () => {
   return (
     <div>
-
       <AuthProvider>
         <Router>
           <Switch>
-            <LoggedInRoute exact path="/" component={Catalog} />
+            <LoggedInRoute exact path="/" component={Home} />
+            <Route exact path="/user/:uid" component={Catalog} />
             <Route exact path="/edit/:id" component={Edit} />
             <Route exact path="/item" component={Item} />
             <Route exact path="/signup" component={SignUp} />

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -5,7 +5,7 @@ import DrinkItem from "./DrinkItem";
 import ModalItemChoice from "./ModalItemChoice";
 import ModalRangePicker from "./ModalRangePicker";
 
-const Catalog = () => {
+const Catalog = ({ history }) => {
   const [drinks, setDrinks] = useState(null);
   const [openModalItemChoice, setOpenModalItemChoice] = useState(false);
   const [startDate, setStartDate] = useState(null);
@@ -93,6 +93,7 @@ const Catalog = () => {
         <ModalItemChoice
           drinks={drinks}
           setOpenModalItemChoice={setOpenModalItemChoice}
+          history={history}
         />
       )}
       <div>

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,0 +1,9 @@
+const Home = () => {
+  return (
+    <div>
+      <h1>ここはHomeコンポーネントです</h1>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from "react";
 import firebase from "../config/firebase";
 import { AuthContext } from "./AuthService";
-import { Redirect } from "react-router"
+import { Redirect } from "react-router";
 
 const Login = ({ history }) => {
   const user = useContext(AuthContext);
@@ -9,7 +9,7 @@ const Login = ({ history }) => {
   const [password, setPassword] = useState("");
 
   if (user) {
-    return <Redirect to={"/"} />
+    return <Redirect to={`/user/${user.uid}`} />;
   }
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -17,12 +17,12 @@ const Login = ({ history }) => {
       .auth()
       .signInWithEmailAndPassword(email, password)
       .then(() => {
-        history.push("/")// "/に移動"
+        history.push(`/user/${user.uid}`);
       })
       .catch((err) => {
         console.log(err);
       });
-  }
+  };
   return (
     <>
       <h1>Login</h1>
@@ -56,8 +56,7 @@ const Login = ({ history }) => {
         <button type="submit">Login</button>
       </form>
     </>
-  );;
-}
-
+  );
+};
 
 export default Login;

--- a/src/Components/ModalItemChoice.js
+++ b/src/Components/ModalItemChoice.js
@@ -3,18 +3,18 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import AllDrinkListItem from "./AllDrinkListItem";
 
-const ModalItemChoice = ({ drinks, setOpenModalItemChoice }) => {
+const ModalItemChoice = ({ drinks, setOpenModalItemChoice, history }) => {
   const [path, setPath] = useState(null);
 
-  //   //OKクリック時の処理
-  //   //AuthProvider導入までhistoryが使えないためコメントアウト
-  //   const onClickPath = () => {
-  //     if (path !== null) {
-  //       history.push(`/edit/${path}`);
-  //     } else {
-  //       alert("お酒が選択されていません");
-  //     }
-  //   };
+  //OKクリック時の処理
+  //AuthProvider導入までhistoryが使えないためコメントアウト
+  const onClickPath = () => {
+    if (path !== null) {
+      history.push(`/${path}`);
+    } else {
+      alert("お酒が選択されていません");
+    }
+  };
 
   return (
     <>
@@ -42,8 +42,8 @@ const ModalItemChoice = ({ drinks, setOpenModalItemChoice }) => {
               })}
           </ul>
           <Link to={`edit/${path}`}>
-            {/* <button onClick={onClickPath}>OK</button> */}
-            <button>OK</button>
+            <button onClick={onClickPath}>OK</button>
+            {/* <button>OK</button> */}
           </Link>
           <p>もしくは</p>
           <Link to="/edit/new">


### PR DESCRIPTION
## Issue

Closes #50 

## 今回の PR で行ったこと

- ModalItemChoiceにて、ルート遷移をAuthProviderを利用したものに変更
- Homeコンポーネントを追加
- catalogコンポーネントをユーザーごとの動的なルーティングにアップデート

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- ルート遷移後のpathを確認
- アイテム選択がエラーなく行えることを確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

- https://zenn.dev/h_yoshikawa0724/articles/2020-09-22-react-router
- https://reffect.co.jp/react/react-router#i-5
- https://ajike.github.io/react-router-dom_hooks/#useparams

## 確認して欲しいこと

-

## 懸念点

-
