### PR TITLE
Itemコンポーネントを動的なルーティングにアップデート

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,8 +15,8 @@ const App = () => {
       <AuthProvider>
         <Router>
           <Switch>
-            <LoggedInRoute exact path="/" component={Home} />
-            <Route exact path="/user/:uid" component={Catalog} />
+            <LoggedInRoute exact path="/user/:uid" component={Catalog} />
+            <Route exact path="/" component={Home} />
             <Route exact path="/new" component={Edit} />
             <Route exact path="/edit/:id" component={Edit} />
             <Route exact path="/user/:uid/items/:did" component={Item} />

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ const App = () => {
           <Switch>
             <LoggedInRoute exact path="/" component={Home} />
             <Route exact path="/user/:uid" component={Catalog} />
+            <Route exact path="/new" component={Edit} />
             <Route exact path="/edit/:id" component={Edit} />
             <Route exact path="/user/:uid/items/:did" component={Item} />
             <Route exact path="/signup" component={SignUp} />

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ const App = () => {
             <LoggedInRoute exact path="/" component={Home} />
             <Route exact path="/user/:uid" component={Catalog} />
             <Route exact path="/edit/:id" component={Edit} />
-            <Route exact path="/item" component={Item} />
+            <Route exact path="/user/:uid/items/:did" component={Item} />
             <Route exact path="/signup" component={SignUp} />
             <Route exact path="/login" component={Login} />
           </Switch>

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -112,6 +112,19 @@ const Catalog = ({ history }) => {
         <h1>ここはCatalogコンポーネントです</h1>
         <button
           onClick={() => {
+            firebase
+              .auth()
+              .signOut()
+              .then(() => history.push("/login"))
+              .catch((err) => {
+                console.log(err);
+              });
+          }}
+        >
+          ログアウト
+        </button>
+        <button
+          onClick={() => {
             setOpenModalItemChoice(true);
           }}
         >

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -123,6 +123,7 @@ const Catalog = ({ history }) => {
               return (
                 <DrinkItem
                   key={drink.id}
+                  id={drink.id}
                   drink={drink.drink}
                   rate={drink.rate}
                   image={drink.image}

--- a/src/Components/DrinkItem.js
+++ b/src/Components/DrinkItem.js
@@ -1,17 +1,21 @@
 import shortid from "shortid";
+import { Link, useRouteMatch } from "react-router-dom";
 
-const DrinkItem = ({ drink, rate, tags, image }) => {
+const DrinkItem = ({ id, drink, rate, tags, image }) => {
+  const match = useRouteMatch();
   return (
     <li>
-      <img src={image} height={100} alt={drink} />
-      <h2>{drink}</h2>
-      <p>レーティング: {rate}</p>
-      <h3>タグ</h3>
-      <ul>
-        {tags.map((tag) => {
-          return <li key={shortid.generate()}>{tag}</li>;
-        })}
-      </ul>
+      <Link to={`${match.url}/items/${id}`}>
+        <img src={image} height={100} alt={drink} />
+        <h2>{drink}</h2>
+        <p>レーティング: {rate}</p>
+        <h3>タグ</h3>
+        <ul>
+          {tags.map((tag) => {
+            return <li key={shortid.generate()}>{tag}</li>;
+          })}
+        </ul>
+      </Link>
     </li>
   );
 };

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,7 +1,16 @@
+import { useContext } from "react";
+import { Link, Redirect } from "react-router-dom";
+import { AuthContext } from "./AuthService";
+
 const Home = () => {
+  const user = useContext(AuthContext);
+  if (user) {
+    return <Redirect to={`/user/${user.uid}`} />;
+  }
   return (
     <div>
       <h1>ここはHomeコンポーネントです</h1>
+      <Link to="/login">無料で始める</Link>
     </div>
   );
 };

--- a/src/Components/Item.js
+++ b/src/Components/Item.js
@@ -1,7 +1,13 @@
+import { useContext } from "react";
+import { useParams } from "react-router-dom";
+import { AuthContext } from "./AuthService";
+
 const Item = () => {
+  const drinkId = useParams().did;
+  const user = useContext(AuthContext);
   return (
     <div>
-      <h1>ここはItemコンポーネントです</h1>
+      <h1>ここはItems/{drinkId}コンポーネントです</h1>
     </div>
   );
 };

--- a/src/Components/LoggedInRoute.js
+++ b/src/Components/LoggedInRoute.js
@@ -1,22 +1,18 @@
-import React, { useContext } from 'react'
-import { Route } from 'react-router'
-import { AuthContext } from './AuthService'
-import { Redirect } from 'react-router'
+import React, { useContext } from "react";
+import { Route } from "react-router-dom";
+import { AuthContext } from "./AuthService";
+import { Redirect } from "react-router-dom";
 
 const LoggedInRoute = ({ component: Component, ...rest }) => {
-    const user = useContext(AuthContext)
-    return (
-        <Route
-            {...rest}
-            render={props =>
-                user ? (
-                    <Component{...props} />
-                ) : (
-                    <Redirect to={'/login'} />
-                )
-            }
-        />
-    )
-}
+  const user = useContext(AuthContext);
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        user ? <Component {...props} /> : <Redirect to={"/"} />
+      }
+    />
+  );
+};
 
-export default LoggedInRoute
+export default LoggedInRoute;

--- a/src/Components/Login.js
+++ b/src/Components/Login.js
@@ -2,6 +2,7 @@ import React, { useState, useContext } from "react";
 import firebase from "../config/firebase";
 import { AuthContext } from "./AuthService";
 import { Redirect } from "react-router";
+import { Link } from "react-router-dom";
 
 const Login = ({ history }) => {
   const user = useContext(AuthContext);
@@ -55,6 +56,7 @@ const Login = ({ history }) => {
         </div>
         <button type="submit">Login</button>
       </form>
+      <Link to="/signup">新規登録</Link>
     </>
   );
 };

--- a/src/Components/ModalItemChoice.js
+++ b/src/Components/ModalItemChoice.js
@@ -10,7 +10,7 @@ const ModalItemChoice = ({ drinks, setOpenModalItemChoice, history }) => {
   //AuthProvider導入までhistoryが使えないためコメントアウト
   const onClickPath = () => {
     if (path !== null) {
-      history.push(`/${path}`);
+      history.push(`/edit/${path}`);
     } else {
       alert("お酒が選択されていません");
     }
@@ -41,9 +41,7 @@ const ModalItemChoice = ({ drinks, setOpenModalItemChoice, history }) => {
                 );
               })}
           </ul>
-          <Link to={`edit/${path}`}>
-            <button onClick={onClickPath}>OK</button>
-          </Link>
+          <button onClick={onClickPath}>OK</button>
           <p>もしくは</p>
           <Link to="/new">
             <button>新しく追加する</button>

--- a/src/Components/ModalItemChoice.js
+++ b/src/Components/ModalItemChoice.js
@@ -43,10 +43,9 @@ const ModalItemChoice = ({ drinks, setOpenModalItemChoice, history }) => {
           </ul>
           <Link to={`edit/${path}`}>
             <button onClick={onClickPath}>OK</button>
-            {/* <button>OK</button> */}
           </Link>
           <p>もしくは</p>
-          <Link to="/edit/new">
+          <Link to="/new">
             <button>新しく追加する</button>
           </Link>
         </SModalInner>


### PR DESCRIPTION
## Issue

Closes #49

## 今回の PR で行ったこと

- Itemコンポーネントを動的なルーティングにアップデート
- editへのpathを変更し、新規追加の場合は"/new"へ遷移
- 未ログインの際の遷移先をHomeへ変更
- Homeからログインページ、ログインページからサインアップへのリンクを追加
- Catalogにサインアウトボタンを追加

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- コンソールにてエラーが出ないことを確認
- editのpathを確認
- Itemのpathを確認
- サインアウトしたときにHomeへ移動することを確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
