### PR TITLE
タグ絞り込み機能の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-scripts": "4.0.3",
     "shortid": "^2.2.16",
     "styled-components": "^5.3.0",
+    "styled-reset": "^4.3.4",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -2,18 +2,21 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Edit from "./Components/Edit";
 import Item from "./Components/Item";
 import Catalog from "./Components/Catalog";
-import { SignUp } from "./Components/SignUp";
+import SignUp from "./Components/SignUp";
 import Login from "./Components/Login";
 // import firebase from "./config/firebase";
 import { AuthProvider } from "./Components/AuthService";
 import LoggedInRoute from "./Components/LoggedInRoute";
 import Home from "./Components/Home";
+import reset from "styled-reset";
+import { createGlobalStyle } from "styled-components";
 
 const App = () => {
   return (
     <div>
       <AuthProvider>
         <Router>
+          <GlobalStyle />
           <Switch>
             <LoggedInRoute exact path="/user/:uid" component={Catalog} />
             <Route exact path="/" component={Home} />
@@ -28,5 +31,16 @@ const App = () => {
     </div>
   );
 };
+
+const GlobalStyle = createGlobalStyle`
+${reset}
+*, *:before, *:after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html{
+  font-size: 62.5%;
+}
+`;
 
 export default App;

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -12,6 +12,7 @@ const Catalog = ({ history }) => {
   const [endDate, setEndDate] = useState(null);
   const [focusedInput, setFocusedInput] = useState("startDate");
   const [openModalRangePicker, setOpenModalRangePicker] = useState(false);
+  const [userTags, setUserTags] = useState(null);
 
   const user = useContext(AuthContext);
 
@@ -19,7 +20,7 @@ const Catalog = ({ history }) => {
   const dateFormat = "YYYY/MM/DD";
 
   //お酒一覧をソートする処理を定義した関数
-  const sortDrink = (drinks) => {
+  const sortDrinks = (drinks) => {
     //①各お酒のdatesの配列を降順（最新順）にする
     drinks.forEach((drink) => {
       drink.dates.sort((a, b) => b - a);
@@ -53,13 +54,12 @@ const Catalog = ({ history }) => {
     return result;
   };
 
-  //お酒リストを取ってくる処理
+  //初回レンダリング時（及び依存配列の更新時）に行われる処理
   useEffect(() => {
     if (user != null) {
-      firebase
-        .firestore()
-        .collection("users")
-        .doc(user.uid)
+      //お酒一覧取得
+      const uidDB = firebase.firestore().collection("users").doc(user.uid);
+      uidDB
         .collection("drinks")
         // .collection(user.uid)
         .onSnapshot((querySnapshot) => {
@@ -71,13 +71,19 @@ const Catalog = ({ history }) => {
             drinks = rangeFilterDrinks(drinks, startDate, endDate);
           }
           //ソート
-          sortDrink(drinks);
+          sortDrinks(drinks);
           //ソートしたものをセット
           setDrinks(drinks);
         });
+      //ユーザータグ一覧取得
+      uidDB.collection("tags").onSnapshot((querySnapshot) => {
+        let tags = querySnapshot.docs.map((doc) => doc.data().tag);
+        setUserTags(tags);
+      });
     }
   }, [user, startDate, endDate]);
   console.log(drinks);
+  console.log(userTags);
 
   return (
     <>

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -15,8 +15,16 @@ const Catalog = ({ history }) => {
   const [openModalRangePicker, setOpenModalRangePicker] = useState(false);
   const [userTags, setUserTags] = useState(null);
   const [openModalTagChoice, setOpenModalTagChoice] = useState(false);
+  const [filterTagArray, setFilterTagArray] = useState([]);
 
   const user = useContext(AuthContext);
+
+  const addFilterTagArray = () => {
+    const results = userTags.filter((userTag) => userTag.trigger === true);
+    const newResults = results.map((result) => result.tag);
+    setFilterTagArray(newResults);
+  };
+  console.log(filterTagArray);
 
   //react-datesの選択期間表示用
   const dateFormat = "YYYY/MM/DD";
@@ -46,21 +54,31 @@ const Catalog = ({ history }) => {
     const endDate00 = endDate.unix() - second12h;
     drinks.forEach((drink) => {
       //指定期間外のdateを配列から削除する
-      const result = drink.dates.filter(
+      drink.dates = drink.dates.filter(
         (date) => startDate00 <= date.seconds && date.seconds <= endDate00
       );
-      drink.dates = result;
     });
     //datesが１つも存在しないものを除外
-    const result = drinks.filter((drink) => drink.dates.length >= 1);
-    return result;
+    drinks = drinks.filter((drink) => drink.dates.length >= 1);
+    return drinks;
+  };
+
+  //タグ絞り込み時の処理を定義した関数
+  const tagFilterDrinks = (filterTagArray, drinks) => {
+    //filterTagArrayの要素を順番にフィルターにかけていく
+    filterTagArray.forEach((tag) => {
+      drinks = drinks.filter((drink) => {
+        return drink.tags.includes(tag);
+      });
+    });
+    return drinks;
   };
 
   //初回レンダリング時（及び依存配列の更新時）に行われる処理
   useEffect(() => {
     if (user != null) {
-      //お酒一覧取得
       const uidDB = firebase.firestore().collection("users").doc(user.uid);
+      //お酒一覧取得
       uidDB
         .collection("drinks")
         // .collection(user.uid)
@@ -72,6 +90,10 @@ const Catalog = ({ history }) => {
           if (startDate && endDate) {
             drinks = rangeFilterDrinks(drinks, startDate, endDate);
           }
+          //タグで絞り込み時にフィルターをかけたものをdrinksに代入
+          if (filterTagArray.length >= 1) {
+            drinks = tagFilterDrinks(filterTagArray, drinks);
+          }
           //ソート
           sortDrinks(drinks);
           //ソートしたものをセット
@@ -80,12 +102,12 @@ const Catalog = ({ history }) => {
       //ユーザータグ一覧取得
       uidDB.collection("tags").onSnapshot((querySnapshot) => {
         let tags = querySnapshot.docs.map((doc) => {
-          return { ...doc.data(), id: doc.id };
+          return { ...doc.data(), id: doc.id, trigger: false };
         });
         setUserTags(tags);
       });
     }
-  }, [user, startDate, endDate]);
+  }, [user, startDate, endDate, filterTagArray]);
   console.log(drinks);
   console.log(userTags);
 
@@ -95,6 +117,7 @@ const Catalog = ({ history }) => {
         <ModalTagChoice
           setOpenModalTagChoice={setOpenModalTagChoice}
           userTags={userTags}
+          addFilterTagArray={addFilterTagArray}
         />
       )}
       {openModalRangePicker && (
@@ -129,6 +152,11 @@ const Catalog = ({ history }) => {
           onFocus={() => setOpenModalRangePicker(true)}
         ></input>
         <button
+          style={
+            filterTagArray.length >= 1
+              ? { backgroundColor: "pink" }
+              : { backgroundColor: "white" }
+          }
           onClick={() => {
             setOpenModalTagChoice(true);
           }}

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -58,7 +58,10 @@ const Catalog = ({ history }) => {
     if (user != null) {
       firebase
         .firestore()
-        .collection(user.uid)
+        .collection("users")
+        .doc(user.uid)
+        .collection("drinks")
+        // .collection(user.uid)
         .onSnapshot((querySnapshot) => {
           let drinks = querySnapshot.docs.map((doc) => {
             return { ...doc.data(), id: doc.id };
@@ -97,7 +100,7 @@ const Catalog = ({ history }) => {
         />
       )}
       <div>
-        {/* inputのままだと注意文が表示されるので、TextFieldなどに変更する */}
+        {/* inputのままだと注意文が表示されるので、TextFieldなどに変更する valueにonClick等をを噛ませていない事による注意文？*/}
         <input
           label="react-dates"
           value={

--- a/src/Components/Catalog.js
+++ b/src/Components/Catalog.js
@@ -4,6 +4,7 @@ import { AuthContext } from "./AuthService";
 import DrinkItem from "./DrinkItem";
 import ModalItemChoice from "./ModalItemChoice";
 import ModalRangePicker from "./ModalRangePicker";
+import ModalTagChoice from "./ModalTagChoice";
 
 const Catalog = ({ history }) => {
   const [drinks, setDrinks] = useState(null);
@@ -13,6 +14,7 @@ const Catalog = ({ history }) => {
   const [focusedInput, setFocusedInput] = useState("startDate");
   const [openModalRangePicker, setOpenModalRangePicker] = useState(false);
   const [userTags, setUserTags] = useState(null);
+  const [openModalTagChoice, setOpenModalTagChoice] = useState(false);
 
   const user = useContext(AuthContext);
 
@@ -77,7 +79,9 @@ const Catalog = ({ history }) => {
         });
       //ユーザータグ一覧取得
       uidDB.collection("tags").onSnapshot((querySnapshot) => {
-        let tags = querySnapshot.docs.map((doc) => doc.data().tag);
+        let tags = querySnapshot.docs.map((doc) => {
+          return { ...doc.data(), id: doc.id };
+        });
         setUserTags(tags);
       });
     }
@@ -87,6 +91,12 @@ const Catalog = ({ history }) => {
 
   return (
     <>
+      {openModalTagChoice && (
+        <ModalTagChoice
+          setOpenModalTagChoice={setOpenModalTagChoice}
+          userTags={userTags}
+        />
+      )}
       {openModalRangePicker && (
         <ModalRangePicker
           startDate={startDate}
@@ -118,6 +128,13 @@ const Catalog = ({ history }) => {
           }
           onFocus={() => setOpenModalRangePicker(true)}
         ></input>
+        <button
+          onClick={() => {
+            setOpenModalTagChoice(true);
+          }}
+        >
+          タグで検索
+        </button>
         <h1>ここはCatalogコンポーネントです</h1>
         <button
           onClick={() => {

--- a/src/Components/Item.js
+++ b/src/Components/Item.js
@@ -1,10 +1,10 @@
-import { useContext } from "react";
+// import { useContext } from "react";
 import { useParams } from "react-router-dom";
-import { AuthContext } from "./AuthService";
+// import { AuthContext } from "./AuthService";
 
 const Item = () => {
   const drinkId = useParams().did;
-  const user = useContext(AuthContext);
+  // const user = useContext(AuthContext);
   return (
     <div>
       <h1>ここはItems/{drinkId}コンポーネントです</h1>

--- a/src/Components/ModalTagChoice.js
+++ b/src/Components/ModalTagChoice.js
@@ -1,9 +1,14 @@
 import styled from "styled-components";
 import UserTagListItem from "./UserTagListItem";
 
-const ModalTagChoice = ({ userTags, setOpenModalTagChoice }) => {
+const ModalTagChoice = ({
+  userTags,
+  setOpenModalTagChoice,
+  addFilterTagArray,
+}) => {
   const onClickOK = () => {
     setOpenModalTagChoice(false);
+    addFilterTagArray();
   };
   return (
     <>
@@ -11,7 +16,7 @@ const ModalTagChoice = ({ userTags, setOpenModalTagChoice }) => {
         <SModalInner>
           <ul>
             {userTags.map((tag) => {
-              return <UserTagListItem tag={tag.tag} key={tag.id} />;
+              return <UserTagListItem tag={tag} key={tag.id} />;
             })}
           </ul>
           <button onClick={onClickOK}>OK</button>

--- a/src/Components/ModalTagChoice.js
+++ b/src/Components/ModalTagChoice.js
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import UserTagListItem from "./UserTagListItem";
+
+const ModalTagChoice = ({ userTags, setOpenModalTagChoice }) => {
+  const onClickOK = () => {
+    setOpenModalTagChoice(false);
+  };
+  return (
+    <>
+      <SModalWrap>
+        <SModalInner>
+          <ul>
+            {userTags.map((tag) => {
+              return <UserTagListItem tag={tag.tag} key={tag.id} />;
+            })}
+          </ul>
+          <button onClick={onClickOK}>OK</button>
+        </SModalInner>
+      </SModalWrap>
+    </>
+  );
+};
+
+const SModalWrap = styled.section`
+  z-index: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const SModalInner = styled.div`
+  background-color: #fffffe;
+  width: calc(1500 / 1920 * 100vw);
+  height: calc(1900 / 1920 * 100vw);
+  border-radius: calc(65 / 1920 * 100vw);
+`;
+
+export default ModalTagChoice;

--- a/src/Components/SignUp.js
+++ b/src/Components/SignUp.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import firebase from "../config/firebase";
 
-export const SignUp = () => {
+const SignUp = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -54,4 +54,4 @@ export const SignUp = () => {
   );
 };
 
-// export default SignUp;
+export default SignUp;

--- a/src/Components/UserTagListItem.js
+++ b/src/Components/UserTagListItem.js
@@ -1,0 +1,9 @@
+const UserTagListItem = ({ tag }) => {
+  return (
+    <li>
+      <button>{tag}</button>
+    </li>
+  );
+};
+
+export default UserTagListItem;

--- a/src/Components/UserTagListItem.js
+++ b/src/Components/UserTagListItem.js
@@ -1,7 +1,24 @@
+import { useState } from "react";
+
 const UserTagListItem = ({ tag }) => {
+  const [tagTrigger, setTagTrigger] = useState(tag.trigger);
+  const setTrigger = () => {
+    tag.trigger = !tag.trigger;
+    setTagTrigger(tag.trigger);
+    console.log(tag.trigger);
+  };
   return (
     <li>
-      <button>{tag}</button>
+      <button
+        onClick={setTrigger}
+        style={
+          tagTrigger
+            ? { backgroundColor: "pink" }
+            : { backgroundColor: "white" }
+        }
+      >
+        {tag.tag}
+      </button>
     </li>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11124,6 +11124,11 @@ styled-components@^5.3.0:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+styled-reset@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-4.3.4.tgz#87b6f43caa3f83a5f9dc63773c13b8bb71efbe69"
+  integrity sha512-1UmkWmRwSPfzolKleyPjbZdBqkxSXv5ImqTP5WeSjWk0Z7IvEzsrYhrqinZfCg10eM1P6BEtFly8+puQJnN/0A==
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"


### PR DESCRIPTION
## Issue

Closes #46

## 今回の PR で行ったこと

- firestoreのデータ構造をusers/ [userID] / drinks / [drinkID] / memos / [memoID]、users/ [userID] / tags / [tagID]に変更
- ユーザーごとのタグ一覧を保持する`userTags`stateを追加
- タグ一覧を表示するModalTagChoiceを作成
- ModalTagChoiceを表示するボタンを作成
- リセットcssとグローバルスタイルの導入
- ModalItemChoiceで各タグボタンを押した時に、userTagsのtriggerをbooleanで変更
- ModalItemChoiceでOKを押したときにtriggerがtrueのものだけ配列として保持する`filterTagArray`stateを作成
- filterTagArrayに配列が存在するときのみ（絞り込みが行われた時）、フィルターを実行

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- レンダリング結果を確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
