### PR TITLE
[add]Edit.jsのタグ選択を<ModalTagChoice>で実行可能に

### DIFF
--- a/src/Components/Pages/Catalog/Catalog.js
+++ b/src/Components/Pages/Catalog/Catalog.js
@@ -13,7 +13,6 @@ const Catalog = ({ history }) => {
   const [endDate, setEndDate] = useState(null);
   const [focusedInput, setFocusedInput] = useState("startDate");
   const [openModalRangePicker, setOpenModalRangePicker] = useState(false);
-  const [userTags, setUserTags] = useState(null);
   const [openModalTagChoice, setOpenModalTagChoice] = useState(false);
   const [filterTagArray, setFilterTagArray] = useState([]);
   const [allDrinks, setAllDrinks] = useState(null);
@@ -95,31 +94,30 @@ const Catalog = ({ history }) => {
           setDrinks(drinks);
         });
       //ユーザータグ一覧取得
-      uidDB.collection("tags").onSnapshot((querySnapshot) => {
-        let tags = querySnapshot.docs.map((doc) => {
-          return { ...doc.data(), id: doc.id, trigger: false };
-        });
-        setUserTags(tags);
-      });
+      // uidDB.collection("tags").onSnapshot((querySnapshot) => {
+      //   let tags = querySnapshot.docs.map((doc) => {
+      //     return { ...doc.data(), id: doc.id, trigger: false };
+      //   });
+      //   setUserTags(tags);
+      // });
     }
   }, [user, startDate, endDate, filterTagArray]);
   console.log(drinks);
-  console.log(userTags);
 
-  //タグ絞り込み（ModalItemChoice）のOKを押した時の処理
-  const addFilterTagArray = () => {
-    const results = userTags.filter((userTag) => userTag.trigger === true);
-    const newResults = results.map((result) => result.tag);
-    setFilterTagArray(newResults);
-  };
+  // //タグ絞り込み（ModalItemChoice）のOKを押した時の処理
+  // const addFilterTagArray = () => {
+  //   const results = userTags.filter((userTag) => userTag.trigger === true);
+  //   const newResults = results.map((result) => result.tag);
+  //   setFilterTagArray(newResults);
+  // };
 
   return (
     <>
       {openModalTagChoice && (
         <ModalTagChoice
           setOpenModalTagChoice={setOpenModalTagChoice}
-          userTags={userTags}
-          addFilterTagArray={addFilterTagArray}
+          user={user}
+          setChoiceTagArray={setFilterTagArray}
         />
       )}
       {openModalRangePicker && (

--- a/src/Components/utility/ModalTagChoice.js
+++ b/src/Components/utility/ModalTagChoice.js
@@ -1,24 +1,73 @@
+import { useState } from "react";
 import styled from "styled-components";
 import UserTagListItem from "./UserTagListItem";
+import firebase from "../../config/firebase";
+import { useEffect } from "react";
+import shortid from "shortid";
 
 const ModalTagChoice = ({
-  userTags,
+  user,
   setOpenModalTagChoice,
-  addFilterTagArray,
+  setChoiceTagArray,
+  newTagInput,
 }) => {
+  const [userTags, setUserTags] = useState(null);
+  const [tagText, setTagText] = useState("");
+
+  useEffect(() => {
+    const uidDB = firebase.firestore().collection("users").doc(user.uid);
+    uidDB.collection("tags").onSnapshot((querySnapshot) => {
+      let tags = querySnapshot.docs.map((doc) => {
+        return { ...doc.data(), id: doc.id, trigger: false };
+      });
+      setUserTags(tags);
+    });
+  }, [user]);
+
+  //新規タグ追加ボタンを押した時の処理
+  // タグを送信して配列に追加する
+  const addTags = (e) => {
+    e.preventDefault();
+    if (tagText === "") return;
+    setUserTags([
+      ...userTags,
+      { tag: tagText, id: shortid.generate(), trigger: false },
+    ]);
+    setTagText("");
+  };
+
+  //OKを押した時の処理
   const onClickOK = () => {
     setOpenModalTagChoice(false);
-    addFilterTagArray();
+    //triggerがtrueのものだけ抽出して配列にする
+    const results = userTags.filter((userTag) => userTag.trigger === true);
+    const newResults = results.map((result) => result.tag);
+    setChoiceTagArray(newResults);
   };
+
   return (
     <>
       <SModalWrap>
         <SModalInner>
           <ul>
-            {userTags.map((tag) => {
-              return <UserTagListItem tag={tag} key={tag.id} />;
-            })}
+            {userTags &&
+              userTags.map((tag) => {
+                return <UserTagListItem tag={tag} key={tag.id} />;
+              })}
           </ul>
+          {newTagInput && (
+            <div>
+              <input
+                name="tag"
+                placeholder="新規タグ追加"
+                value={tagText}
+                onChange={(e) => {
+                  setTagText(e.target.value);
+                }}
+              />
+              <button onClick={addTags}>新規タグ追加</button>
+            </div>
+          )}
           <button onClick={onClickOK}>OK</button>
         </SModalInner>
       </SModalWrap>

--- a/src/Components/utility/TagsList.js
+++ b/src/Components/utility/TagsList.js
@@ -1,11 +1,13 @@
 import TagsListItem from "./TagsListItem";
+import shortid from "shortid";
 
 const TagsList = ({ tags }) => {
   return (
     <ul>
-      {tags.map((tag, index) => {
-        return <TagsListItem content={tag} key={index} />;
-      })}
+      {tags &&
+        tags.map((tag, index) => {
+          return <TagsListItem content={tag} key={shortid.generate()} />;
+        })}
     </ul>
   );
 };


### PR DESCRIPTION
## Issue

Closes #41 

## 今回の PR で行ったこと

- ModalTagChoiceを使い回すため、タグリストの展開とstateの管理をCatalog.jsからModalTagChoice.jsに移動
- Edit.jsでも<ModalTagChoice>を使用できるようにstateを変更
- タグ追加ボタンを押すと、ModalTagChoiceが表示
- Edit.jsから表示した時のみ、新規タグ追加欄が表示されるように
- ModalTagChoiceでタグを選択＆OKボタンを押した後、Edit.jsに選択したタグが表示される

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- レンダリング結果の確認
- consoleの確認
- firestoreの確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
