### PR TITLE
お酒詳細ページの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ const App = () => {
             <Route exact path="/" component={Home} />
             <LoggedInRoute exact path="/new" component={Edit} />
             <LoggedInRoute exact path="/edit/:id" component={Edit} />
+            <LoggedInRoute exact path="/edit/:id/:mid" component={Edit} />
             <LoggedInRoute
               exact
               path="/user/:uid/items/:did"

--- a/src/Components/Pages/Item/Components/MemoListItem.js
+++ b/src/Components/Pages/Item/Components/MemoListItem.js
@@ -1,12 +1,41 @@
 import { Link } from "react-router-dom";
+import { makeStyles } from "@material-ui/core/styles";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import Typography from "@material-ui/core/Typography";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100%",
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    fontWeight: theme.typography.fontWeightRegular,
+  },
+}));
 
 const MemoListItem = ({ memo, id, date, drinkId }) => {
+  const classes = useStyles();
   return (
     <li>
-      <h3>{date}</h3>
-      <p>{memo}</p>
-      <Link to={`/edit/${drinkId}/${id}`}>編集</Link>
-      <button>削除</button>
+      <div className={classes.root}>
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
+          >
+            <Typography className={classes.heading}>{date}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>{memo}</Typography>
+            <Link to={`/edit/${drinkId}/${id}`}>編集</Link>
+            <button>削除</button>
+          </AccordionDetails>
+        </Accordion>
+      </div>
     </li>
   );
 };

--- a/src/Components/Pages/Item/Components/MemoListItem.js
+++ b/src/Components/Pages/Item/Components/MemoListItem.js
@@ -1,0 +1,14 @@
+import { Link } from "react-router-dom";
+
+const MemoListItem = ({ memo, id, date, drinkId }) => {
+  return (
+    <li>
+      <h3>{date}</h3>
+      <p>{memo}</p>
+      <Link to={`/edit/${drinkId}/${id}`}>編集</Link>
+      <button>削除</button>
+    </li>
+  );
+};
+
+export default MemoListItem;

--- a/src/Components/Pages/Item/Item.js
+++ b/src/Components/Pages/Item/Item.js
@@ -1,14 +1,74 @@
-// import { useContext } from "react";
+import { useEffect, useState } from "react";
+import { useContext } from "react";
 import { useParams } from "react-router-dom";
-// import { AuthContext } from "./AuthService";
+import { AuthContext } from "../../utility/AuthService";
+import firebase from "../../../config/firebase";
+import TagList from "../../utility/TagsList";
+import MemoListItem from "./Components/MemoListItem";
 
 const Item = () => {
+  const [drinkData, setDrinkData] = useState(null);
+  const [memos, setMemos] = useState(null);
+
   const drinkId = useParams().did;
-  // const user = useContext(AuthContext);
+  const user = useContext(AuthContext);
+
+  useEffect(() => {
+    if (user != null) {
+      const uidDB = firebase.firestore().collection("users").doc(user.uid);
+      const drinkDoc = uidDB.collection("drinks").doc(drinkId);
+      drinkDoc.onSnapshot((doc) => {
+        const drinkData = { ...doc.data(), id: doc.id };
+        setDrinkData(drinkData);
+      });
+      drinkDoc
+        .collection("memos")
+        .orderBy("date")
+        .onSnapshot((querySnapshot) => {
+          const memos = querySnapshot.docs.map((doc) => {
+            const yyyy = doc.data().date.toDate().getFullYear();
+            const mm = ("0" + (doc.data().date.toDate().getMonth() + 1)).slice(
+              -2
+            );
+            const dd = ("0" + doc.data().date.toDate().getDate()).slice(-2);
+            const YMD = `${yyyy}/${mm}/${dd}`;
+            return { ...doc.data(), id: doc.id, YMDDate: YMD };
+          });
+          console.log(memos);
+          setMemos(memos);
+        });
+    }
+  }, [user, drinkId]);
+  console.log(drinkData);
+  console.log(memos);
+
   return (
-    <div>
-      <h1>ここはItems/{drinkId}コンポーネントです</h1>
-    </div>
+    drinkData && (
+      <div>
+        <img src={drinkData.image} height={200} alt={drinkData.drink} />
+        <h1>{drinkData.drink}</h1>
+        <h2>レーティング: {drinkData.rate}</h2>
+        <button>今日飲んだ！</button>
+        <TagList tags={drinkData.tags} />
+        <div>
+          <ul>
+            {memos &&
+              memos.map((memo) => {
+                return (
+                  <MemoListItem
+                    key={memo.id}
+                    drinkId={drinkId}
+                    id={memo.id}
+                    memo={memo.memo}
+                    date={memo.YMDDate}
+                  />
+                );
+              })}
+          </ul>
+        </div>
+        <button>まとめて削除</button>
+      </div>
+    )
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
## Issue

Closes #38

## 今回の PR で行ったこと

- firebaseからクリックしたお酒のIDを持つドキュメントを取得、配列に展開。
- メモサブコレクションを取得、展開
- 画像、お酒名、レーティング、メモ一覧を表示
- materialUI/iconsのインストール
- メモ表示をアコーディオンに変更
- 削除・編集用ボタンの追加

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- レンダリング結果確認済み

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
