### PR TITLE
メールアドレス変更機能の追加

### DIFF
--- a/src/Components/Pages/Config/Components/ModalConfirmPassword.js
+++ b/src/Components/Pages/Config/Components/ModalConfirmPassword.js
@@ -2,14 +2,13 @@ import { useState, useRef, useContext } from "react";
 import styled from "styled-components";
 import { AuthContext } from "../../../utility/AuthService";
 
-const ModalUpdateEmail = ({ setOpen, setOpenConfirm }) => {
-  const user = useContext(AuthContext);
+const ModalConfirmPassword = ({ setOpen }) => {
   const modalRef = useRef(null);
-  const [email, setEmail] = useState(user.email);
+  const [password, setPassword] = useState("");
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    setOpenConfirm(true);
+    return;
   };
 
   return (
@@ -22,17 +21,17 @@ const ModalUpdateEmail = ({ setOpen, setOpenConfirm }) => {
         }}
       >
         <SModalInner ref={modalRef}>
-          <h1>メールアドレス変更</h1>
+          <h1>パスワード確認</h1>
           <form onSubmit={handleSubmit}>
             <div>
               <input
-                type="email"
-                id="email"
-                name="email"
-                placeholder="メールアドレス"
-                value={email}
+                type="password"
+                id="password"
+                name="password"
+                placeholder="パスワード"
+                value={password}
                 onChange={(e) => {
-                  setEmail(e.target.value);
+                  setPassword(e.target.value);
                 }}
               />
             </div>
@@ -45,7 +44,7 @@ const ModalUpdateEmail = ({ setOpen, setOpenConfirm }) => {
 };
 
 const SModalWrap = styled.section`
-  z-index: 3;
+  z-index: 4;
   position: fixed;
   top: 0;
   left: 0;
@@ -61,8 +60,8 @@ const SModalInner = styled.div`
   color: #000;
   background-color: #fffffe;
   width: calc(1500 / 1920 * 100vw);
-  height: calc(1900 / 1920 * 100vw);
+  height: calc(1500 / 1920 * 100vw);
   border-radius: calc(65 / 1920 * 100vw);
 `;
 
-export default ModalUpdateEmail;
+export default ModalConfirmPassword;

--- a/src/Components/Pages/Config/Components/ModalConfirmPassword.js
+++ b/src/Components/Pages/Config/Components/ModalConfirmPassword.js
@@ -2,14 +2,13 @@ import { useState, useRef, useContext } from "react";
 import styled from "styled-components";
 import { AuthContext } from "../../../utility/AuthService";
 
-const ModalConfirmPassword = ({ setOpen }) => {
+const ModalConfirmPassword = ({
+  setOpen,
+  onSubmitConfirmPassword,
+  setPassword,
+  password,
+}) => {
   const modalRef = useRef(null);
-  const [password, setPassword] = useState("");
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    return;
-  };
 
   return (
     <>
@@ -22,7 +21,7 @@ const ModalConfirmPassword = ({ setOpen }) => {
       >
         <SModalInner ref={modalRef}>
           <h1>パスワード確認</h1>
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={onSubmitConfirmPassword}>
             <div>
               <input
                 type="password"

--- a/src/Components/Pages/Config/Components/ModalConfirmPassword.js
+++ b/src/Components/Pages/Config/Components/ModalConfirmPassword.js
@@ -2,12 +2,7 @@ import { useState, useRef, useContext } from "react";
 import styled from "styled-components";
 import { AuthContext } from "../../../utility/AuthService";
 
-const ModalConfirmPassword = ({
-  setOpen,
-  onSubmitConfirmPassword,
-  setPassword,
-  password,
-}) => {
+const ModalConfirmPassword = ({ setOpen, onSubmit, setPassword, password }) => {
   const modalRef = useRef(null);
 
   return (
@@ -21,7 +16,7 @@ const ModalConfirmPassword = ({
       >
         <SModalInner ref={modalRef}>
           <h1>パスワード確認</h1>
-          <form onSubmit={onSubmitConfirmPassword}>
+          <form onSubmit={onSubmit}>
             <div>
               <input
                 type="password"

--- a/src/Components/Pages/Config/Components/ModalUpdateEmail.js
+++ b/src/Components/Pages/Config/Components/ModalUpdateEmail.js
@@ -1,19 +1,49 @@
+import { useEffect } from "react";
 import { useState, useRef, useContext } from "react";
 import styled from "styled-components";
 import { AuthContext } from "../../../utility/AuthService";
+import ModalConfirmPassword from "./ModalConfirmPassword";
 
 const ModalUpdateEmail = ({ setOpen, setOpenConfirm }) => {
   const user = useContext(AuthContext);
   const modalRef = useRef(null);
   const [email, setEmail] = useState(user.email);
+  const [openModalConfirmPassword, setOpenModalConfirmPassword] =
+    useState(false);
+  const [password, setPassword] = useState("");
+  const [provider, setProvider] = useState(null);
 
-  const handleSubmit = (e) => {
+  useEffect(() => {
+    if (user !== null) {
+      user.providerData.forEach((profile) => {
+        setProvider(profile.providerId);
+      });
+    }
+  }, [user]);
+
+  console.log(provider);
+
+  //OKボタンを押した時の処理
+  const onSubmitEmail = (e) => {
     e.preventDefault();
-    setOpenConfirm(true);
+    setOpenModalConfirmPassword(true);
+  };
+
+  //ModalConfirmPassword(パスワード確認)でOKを押した時の処理
+  const onSubmitConfirmPassword = (e) => {
+    e.preventDefault();
   };
 
   return (
     <>
+      {openModalConfirmPassword && (
+        <ModalConfirmPassword
+          setOpen={setOpenModalConfirmPassword}
+          onSubmit={onSubmitConfirmPassword}
+          setPassword={setPassword}
+          password={password}
+        />
+      )}
       <SModalWrap
         onClick={(e) => {
           //モーダルウィンドウの外側がクリックされたか判定、外側なら閉じる
@@ -22,22 +52,31 @@ const ModalUpdateEmail = ({ setOpen, setOpenConfirm }) => {
         }}
       >
         <SModalInner ref={modalRef}>
-          <h1>メールアドレス変更</h1>
-          <form onSubmit={handleSubmit}>
+          {provider === "google.com" && (
             <div>
-              <input
-                type="email"
-                id="email"
-                name="email"
-                placeholder="メールアドレス"
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                }}
-              />
+              <p>{provider}でログインしているため、変更できません</p>
             </div>
-            <button type="submit">OK</button>
-          </form>
+          )}
+          {/* {provider !== "google.com" && ( */}
+          <div>
+            <h1>メールアドレス変更</h1>
+            <form onSubmit={onSubmitEmail}>
+              <div>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  placeholder="メールアドレス"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                  }}
+                />
+              </div>
+              <button type="submit">OK</button>
+            </form>
+          </div>
+          {/* )} */}
         </SModalInner>
       </SModalWrap>
     </>

--- a/src/Components/Pages/Config/Components/ModalUpdateEmail.js
+++ b/src/Components/Pages/Config/Components/ModalUpdateEmail.js
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { useRef } from "react";
+import styled from "styled-components";
+
+const ModalUpdateEmail = ({ setOpen }) => {
+  const modalRef = useRef(null);
+  const [email, setEmail] = useState("");
+
+  const handleSubmit = () => {
+    return;
+  };
+
+  return (
+    <>
+      <SModalWrap
+        onClick={(e) => {
+          //モーダルウィンドウの外側がクリックされたか判定、外側なら閉じる
+          if (modalRef.current.contains(e.target)) return;
+          setOpen(false);
+        }}
+      >
+        <SModalInner ref={modalRef}>
+          <h1>メールアドレス変更</h1>
+          <form onSubmit={handleSubmit}>
+            <div>
+              <label htmlFor="email">新しいメールアドレス</label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                }}
+              />
+            </div>
+            <button type="submit">OK</button>
+          </form>
+        </SModalInner>
+      </SModalWrap>
+    </>
+  );
+};
+
+const SModalWrap = styled.section`
+  z-index: 3;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const SModalInner = styled.div`
+  color: #000;
+  background-color: #fffffe;
+  width: calc(1500 / 1920 * 100vw);
+  height: calc(1900 / 1920 * 100vw);
+  border-radius: calc(65 / 1920 * 100vw);
+`;
+
+export default ModalUpdateEmail;

--- a/src/Components/Pages/Config/Components/ModalUpdatePassword.js
+++ b/src/Components/Pages/Config/Components/ModalUpdatePassword.js
@@ -1,0 +1,62 @@
+import { useRef, useState, useContext } from "react";
+import styled from "styled-components";
+import { AuthContext } from "../../../utility/AuthService";
+
+const ModalUpdatePassword = ({ setOpen }) => {
+  const modalRef = useRef(null);
+  const [password, setPassword] = useState("");
+  const user = useContext(AuthContext);
+
+  return (
+    <>
+      <SModalWrap
+        onClick={(e) => {
+          //モーダルウィンドウの外側がクリックされたか判定、外側なら閉じる
+          if (modalRef.current.contains(e.target)) return;
+          setOpen(false);
+        }}
+      >
+        <SModalInner ref={modalRef}>
+          <h1>パスワードの確認が必要です</h1>
+          <form>
+            <div>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                placeholder="現在のパスワード"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                }}
+              />
+            </div>
+          </form>
+        </SModalInner>
+      </SModalWrap>
+    </>
+  );
+};
+
+const SModalWrap = styled.section`
+  z-index: 3;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const SModalInner = styled.div`
+  color: #000;
+  background-color: #fffffe;
+  width: calc(1500 / 1920 * 100vw);
+  height: calc(1900 / 1920 * 100vw);
+  border-radius: calc(65 / 1920 * 100vw);
+`;
+
+export default ModalUpdatePassword;

--- a/src/Components/Pages/Config/index.js
+++ b/src/Components/Pages/Config/index.js
@@ -4,10 +4,13 @@ import firebase from "../../../config/firebase";
 import { useState } from "react";
 import ModalUpdateEmail from "./Components/ModalUpdateEmail";
 import ModalUpdatePassword from "./Components/ModalUpdatePassword";
+import ModalConfirmPassword from "./Components/ModalConfirmPassword";
 
 const Config = ({ history }) => {
   const [openModalUpdateEmail, setOpenModalUpdateEmail] = useState(false);
   const [openModalUpdatePassword, setOpenModalUpdatePassword] = useState(false);
+  const [openModalConfirmPassword, setOpenModalConfirmPassword] =
+    useState(false);
 
   //ログアウト処理
   const onClickLogout = () => {
@@ -23,8 +26,14 @@ const Config = ({ history }) => {
   return (
     <>
       <Header />
+      {openModalConfirmPassword && (
+        <ModalConfirmPassword setOpen={setOpenModalConfirmPassword} />
+      )}
       {openModalUpdateEmail && (
-        <ModalUpdateEmail setOpen={setOpenModalUpdateEmail} />
+        <ModalUpdateEmail
+          setOpen={setOpenModalUpdateEmail}
+          setOpenConfirm={setOpenModalConfirmPassword}
+        />
       )}
       {openModalUpdatePassword && (
         <ModalUpdatePassword setOpen={setOpenModalUpdatePassword} />

--- a/src/Components/Pages/Config/index.js
+++ b/src/Components/Pages/Config/index.js
@@ -1,8 +1,14 @@
 import Footer from "../../utility/Footer";
 import Header from "../../utility/Header";
 import firebase from "../../../config/firebase";
+import { useState } from "react";
+import ModalUpdateEmail from "./Components/ModalUpdateEmail";
+import ModalUpdatePassword from "./Components/ModalUpdatePassword";
 
 const Config = ({ history }) => {
+  const [openModalUpdateEmail, setOpenModalUpdateEmail] = useState(false);
+  const [openModalUpdatePassword, setOpenModalUpdatePassword] = useState(false);
+
   //ログアウト処理
   const onClickLogout = () => {
     firebase
@@ -17,10 +23,22 @@ const Config = ({ history }) => {
   return (
     <>
       <Header />
+      {openModalUpdateEmail && (
+        <ModalUpdateEmail setOpen={setOpenModalUpdateEmail} />
+      )}
+      {openModalUpdatePassword && (
+        <ModalUpdatePassword setOpen={setOpenModalUpdatePassword} />
+      )}
       <div>
         <h1>Configページ</h1>
         <button>パスワード変更</button>
-        <button>メールアドレス変更</button>
+        <button
+          onClick={() => {
+            setOpenModalUpdateEmail(true);
+          }}
+        >
+          メールアドレス変更
+        </button>
         <button onClick={onClickLogout}>ログアウト</button>
       </div>
       <Footer />

--- a/src/Components/Pages/Config/index.js
+++ b/src/Components/Pages/Config/index.js
@@ -4,13 +4,10 @@ import firebase from "../../../config/firebase";
 import { useState } from "react";
 import ModalUpdateEmail from "./Components/ModalUpdateEmail";
 import ModalUpdatePassword from "./Components/ModalUpdatePassword";
-import ModalConfirmPassword from "./Components/ModalConfirmPassword";
 
 const Config = ({ history }) => {
   const [openModalUpdateEmail, setOpenModalUpdateEmail] = useState(false);
   const [openModalUpdatePassword, setOpenModalUpdatePassword] = useState(false);
-  const [openModalConfirmPassword, setOpenModalConfirmPassword] =
-    useState(false);
 
   //ログアウト処理
   const onClickLogout = () => {
@@ -26,14 +23,8 @@ const Config = ({ history }) => {
   return (
     <>
       <Header />
-      {openModalConfirmPassword && (
-        <ModalConfirmPassword setOpen={setOpenModalConfirmPassword} />
-      )}
       {openModalUpdateEmail && (
-        <ModalUpdateEmail
-          setOpen={setOpenModalUpdateEmail}
-          setOpenConfirm={setOpenModalConfirmPassword}
-        />
+        <ModalUpdateEmail setOpen={setOpenModalUpdateEmail} />
       )}
       {openModalUpdatePassword && (
         <ModalUpdatePassword setOpen={setOpenModalUpdatePassword} />

--- a/src/Components/Pages/Edit/Edit.js
+++ b/src/Components/Pages/Edit/Edit.js
@@ -64,7 +64,7 @@ const Edit = ({ history }) => {
         setChoiceTagArray(drink.tags);
       });
     }
-  }, []);
+  }, [db, did, user.uid]);
 
   //画像をアップロード
   const onSelectFile = (e) => {

--- a/src/Components/Pages/SignUp/SignUp.js
+++ b/src/Components/Pages/SignUp/SignUp.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import firebase from "../../../config/firebase";
 
-const SignUp = () => {
+const SignUp = ({ history }) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -11,6 +11,8 @@ const SignUp = () => {
       .auth()
       .createUserWithEmailAndPassword(email, password)
       .then(() => {
+        const user = firebase.auth().currentUser;
+        history.push(`/user/${user.uid}`);
         return "成功";
       })
       .catch((err) => {


### PR DESCRIPTION
## Issue

Closes #93

## 今回の PR で行ったこと

- メールアドレス/パスワード変更をモーダルウィンドウで表示
- パスワード確認用モーダルウィンドウの追加
- Googleログイン時は「google.comでログインしているため、変更できません」と表示される機能を追加
- ユーザーの再認証機能の追加
- メールアドレス変更機能の追加
- 確認メール送信機能の追加

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- console.logで確認
- user.emailを確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- Config/index.js

## 実装するにあたって参考にした URL

- https://firebase.google.com/docs/auth/web/manage-users?hl=ja#re-authenticate_a_user

## 確認して欲しいこと

-

## 懸念点

-
